### PR TITLE
base64 decode messages in POST bindings.

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -78,7 +78,12 @@ module SamlIdp
     def decode_request(raw_saml_request)
       case request.request_method
       when "POST"
-        self.saml_request = Request.new raw_saml_request
+        # Request is Base64 encoded. See #3.5.4 of
+        # http://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf
+        #
+        # Note that while this specific stanza does not list it, the rest of the doc
+        # cites RFC 2045 as the base64 standard.
+        self.saml_request = Request.new(Base64.decode64(raw_saml_request))
       when "GET"
         # SAML Requests via GET are using the redirect binding which defaltes and
         # base64 encodes a SAML Request.

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -116,15 +116,14 @@ describe SamlIdp::Controller do
 
   context "Single Logout" do
     before(:each) do
-      # TODO(awong): Test POST.
-      params[:SAMLRequest] = SamlIdp::LogoutRequestBuilder.new(
+      params[:SAMLRequest] = Base64.encode64(SamlIdp::LogoutRequestBuilder.new(
         '_response_id',
         'localhost:3000',
         'http://localhost:1337/saml/logout',
         'himom',
         'some_qualifier',
         'abc123index',
-        signature_opts).build.to_xml
+        signature_opts).build.to_xml)
       @request = MockRequest.new('POST')
       validate_saml_request
     end


### PR DESCRIPTION
SAML 2.0 bindings spec #3.5.4 specifies messages should be base64
encoded before being URL encoded. Ruby handles the URL decoding
magically. This CL does the base64 decoding. Without this fix, the
POST binding implementation is non-compliant.
