### PR TITLE
Make signature verification more loose with trust chain verification.

### DIFF
--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -1,0 +1,168 @@
+# The contents of this file are subject to the terms
+# of the Common Development and Distribution License
+# (the License). You may not use this file except in
+# compliance with the License.
+#
+# You can obtain a copy of the License at
+# https://opensso.dev.java.net/public/CDDLv1.0.html or
+# opensso/legal/CDDLv1.0.txt
+# See the License for the specific language governing
+# permission and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL
+# Header Notice in each file and include the License file
+# at opensso/legal/CDDLv1.0.txt.
+# If applicable, add the following below the CDDL Header,
+# with the fields enclosed by brackets [] replaced by
+# your own identifying information:
+# "Portions Copyrighted [year] [name of copyright owner]"
+#
+# $Id: xml_sec.rb,v 1.6 2007/10/24 00:28:41 todddd Exp $
+#
+# Copyright 2007 Sun Microsystems Inc. All Rights Reserved
+# Portions Copyrighted 2007 Todd W Saxton.
+
+require "rexml/document"
+require "rexml/xpath"
+require "openssl"
+require 'nokogiri'
+require "digest/sha1"
+require "digest/sha2"
+
+module SamlIdp
+  module XMLSecurity
+    class SignedDocument < REXML::Document
+      ValidationError = Class.new(StandardError)
+      C14N = "http://www.w3.org/2001/10/xml-exc-c14n#"
+      DSIG = "http://www.w3.org/2000/09/xmldsig#"
+
+      attr_accessor :signed_element_id
+
+      def initialize(response)
+        super(response)
+        extract_signed_element_id
+      end
+
+      def validate(idp_cert_fingerprint, soft = true)
+        # get cert from response
+        cert_element = REXML::XPath.first(self, "//ds:X509Certificate", { "ds"=>DSIG })
+        raise ValidationError.new("Certificate element missing in response (ds:X509Certificate)") unless cert_element
+        base64_cert  = cert_element.text
+        cert_text    = Base64.decode64(base64_cert)
+        cert         = OpenSSL::X509::Certificate.new(cert_text)
+
+        # check cert matches registered idp cert
+        fingerprint = Digest::SHA1.hexdigest(cert.to_der)
+
+        if fingerprint != idp_cert_fingerprint.gsub(/[^a-zA-Z0-9]/,"").downcase
+          return soft ? false : (raise ValidationError.new("Fingerprint mismatch"))
+        end
+
+        validate_doc(base64_cert, soft)
+      end
+
+      def validate_doc(base64_cert, soft = true)
+        # validate references
+
+        # check for inclusive namespaces
+        inclusive_namespaces = extract_inclusive_namespaces
+
+        document = Nokogiri.parse(self.to_s)
+
+        # create a working copy so we don't modify the original
+        @working_copy ||= REXML::Document.new(self.to_s).root
+
+        # store and remove signature node
+        @sig_element ||= begin
+                           element = REXML::XPath.first(@working_copy, "//ds:Signature", {"ds"=>DSIG})
+                           element.remove
+                         end
+
+
+        # verify signature
+        signed_info_element     = REXML::XPath.first(@sig_element, "//ds:SignedInfo", {"ds"=>DSIG})
+        noko_sig_element = document.at_xpath('//ds:Signature', 'ds' => DSIG)
+        noko_signed_info_element = noko_sig_element.at_xpath('./ds:SignedInfo', 'ds' => DSIG)
+        canon_algorithm = canon_algorithm REXML::XPath.first(@sig_element, '//ds:CanonicalizationMethod', 'ds' => DSIG)
+        canon_string = noko_signed_info_element.canonicalize(canon_algorithm)
+        noko_sig_element.remove
+
+        # check digests
+        REXML::XPath.each(@sig_element, "//ds:Reference", {"ds"=>DSIG}) do |ref|
+          uri                           = ref.attributes.get_attribute("URI").value
+
+          hashed_element                = document.at_xpath("//*[@ID='#{uri[1..-1]}']")
+          canon_algorithm               = canon_algorithm REXML::XPath.first(ref, '//ds:CanonicalizationMethod', 'ds' => DSIG)
+          canon_hashed_element          = hashed_element.canonicalize(canon_algorithm, inclusive_namespaces)
+
+          digest_algorithm              = algorithm(REXML::XPath.first(ref, "//ds:DigestMethod"))
+
+          hash                          = digest_algorithm.digest(canon_hashed_element)
+          digest_value                  = Base64.decode64(REXML::XPath.first(ref, "//ds:DigestValue", {"ds"=>DSIG}).text)
+
+          unless digests_match?(hash, digest_value)
+            return soft ? false : (raise ValidationError.new("Digest mismatch"))
+          end
+        end
+
+        base64_signature        = REXML::XPath.first(@sig_element, "//ds:SignatureValue", {"ds"=>DSIG}).text
+        signature               = Base64.decode64(base64_signature)
+
+        # get certificate object
+        cert_text               = Base64.decode64(base64_cert)
+        cert                    = OpenSSL::X509::Certificate.new(cert_text)
+
+        # signature method
+        signature_algorithm     = algorithm(REXML::XPath.first(signed_info_element, "//ds:SignatureMethod", {"ds"=>DSIG}))
+
+        unless cert.public_key.verify(signature_algorithm.new, signature, canon_string)
+          return soft ? false : (raise ValidationError.new("Key validation error"))
+        end
+
+        return true
+      end
+
+      private
+
+      def digests_match?(hash, digest_value)
+        hash == digest_value
+      end
+
+      def extract_signed_element_id
+        reference_element       = REXML::XPath.first(self, "//ds:Signature/ds:SignedInfo/ds:Reference", {"ds"=>DSIG})
+        self.signed_element_id  = reference_element.attribute("URI").value[1..-1] unless reference_element.nil?
+      end
+
+      def canon_algorithm(element)
+        algorithm = element.attribute('Algorithm').value if element
+        case algorithm
+        when "http://www.w3.org/2001/10/xml-exc-c14n#"         then Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
+        when "http://www.w3.org/TR/2001/REC-xml-c14n-20010315" then Nokogiri::XML::XML_C14N_1_0
+        when "http://www.w3.org/2006/12/xml-c14n11"            then Nokogiri::XML::XML_C14N_1_1
+        else                                                        Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
+        end
+      end
+
+      def algorithm(element)
+        algorithm = element.attribute("Algorithm").value if element
+        algorithm = algorithm && algorithm =~ /sha(.*?)$/i && $1.to_i
+        case algorithm
+        when 256 then OpenSSL::Digest::SHA256
+        when 384 then OpenSSL::Digest::SHA384
+        when 512 then OpenSSL::Digest::SHA512
+        else
+          OpenSSL::Digest::SHA1
+        end
+      end
+
+      def extract_inclusive_namespaces
+        if element = REXML::XPath.first(self, "//ec:InclusiveNamespaces", { "ec" => C14N })
+          prefix_list = element.attributes.get_attribute("PrefixList").value
+          prefix_list.split(" ")
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -95,7 +95,7 @@ module SamlIdp
           canon_algorithm               = canon_algorithm REXML::XPath.first(ref, '//ds:CanonicalizationMethod', 'ds' => DSIG)
           canon_hashed_element          = hashed_element.canonicalize(canon_algorithm, inclusive_namespaces)
 
-          digest_algorithm              = algorithm(REXML::XPath.first(ref, "//ds:DigestMethod"))
+          digest_algorithm              = algorithm(REXML::XPath.first(ref, "//ds:DigestMethod", 'ds' => DSIG))
 
           hash                          = digest_algorithm.digest(canon_hashed_element)
           digest_value                  = Base64.decode64(REXML::XPath.first(ref, "//ds:DigestValue", {"ds"=>DSIG}).text)

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+require 'xml_security'
+
+module SamlIdp
+  describe XMLSecurity, security: true do
+    let(:document) { XMLSecurity::SignedDocument.new(Base64.decode64(response_document)) }
+    let(:base64cert) { document.elements["//ds:X509Certificate"].text }
+
+    it "it run validate without throwing NS related exceptions" do
+      document.validate_doc(base64cert, true).should be_falsey
+    end
+
+    it "it run validate with throwing NS related exceptions" do
+      expect { document.validate_doc(base64cert, false) }.to raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError)
+    end
+
+    it "not raise an error when softly validating the document multiple times" do
+      expect { 2.times { document.validate_doc(base64cert, true) } }.to_not raise_error
+    end
+
+    it "it raise Fingerprint mismatch" do
+      expect { document.validate("no:fi:ng:er:pr:in:t", false) }.to(
+        raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError, "Fingerprint mismatch")
+      )
+    end
+
+    it "it raise Digest mismatch" do
+      expect { document.validate_doc(base64cert, false) }.to(
+        raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError, "Digest mismatch")
+      )
+    end
+
+    it "it raise Key validation error" do
+      response = Base64.decode64(response_document)
+      response.sub!("<ds:DigestValue>pJQ7MS/ek4KRRWGmv/H43ReHYMs=</ds:DigestValue>",
+                    "<ds:DigestValue>b9xsAXLsynugg3Wc1CI3kpWku+0=</ds:DigestValue>")
+      document = XMLSecurity::SignedDocument.new(response)
+      base64cert = document.elements["//ds:X509Certificate"].text
+      expect { document.validate_doc(base64cert, false) }.to(
+        raise_error(SamlIdp::XMLSecurity::SignedDocument::ValidationError, "Key validation error")
+      )
+    end
+
+    it "raise validation error when the X509Certificate is missing" do
+      response = Base64.decode64(response_document)
+      response.sub!(/<ds:X509Certificate>.*<\/ds:X509Certificate>/, "")
+      document = XMLSecurity::SignedDocument.new(response)
+      expect { document.validate("a fingerprint", false) }.to(
+        raise_error(
+          SamlIdp::XMLSecurity::SignedDocument::ValidationError,
+          "Certificate element missing in response (ds:X509Certificate)"
+        )
+      )
+    end
+  end
+
+  describe "Algorithms" do
+    it "validate using SHA1" do
+      document = XMLSecurity::SignedDocument.new(fixture_response(:adfs_response_sha1, false))
+      document.validate("F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72").should be_truthy
+    end
+
+    it "validate using SHA256" do
+      document = XMLSecurity::SignedDocument.new(fixture_response(:adfs_response_sha256, false))
+      document.validate("28:74:9B:E8:1F:E8:10:9C:A8:7C:A9:C3:E3:C5:01:6C:92:1C:B4:BA").should be_truthy
+    end
+
+    it "validate using SHA384" do
+      document = XMLSecurity::SignedDocument.new(fixture_response(:adfs_response_sha384, false))
+      document.validate("F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72").should be_truthy
+    end
+
+    it "validate using SHA512" do
+      document = XMLSecurity::SignedDocument.new(fixture_response(:adfs_response_sha512, false))
+      document.validate("F1:3C:6B:80:90:5A:03:0E:6C:91:3E:5D:15:FA:DD:B0:16:45:48:72").should be_truthy
+    end
+  end
+
+  describe "XmlSecurity::SignedDocument" do
+    describe "#extract_inclusive_namespaces" do
+      it "support explicit namespace resolution for exclusive canonicalization" do
+        response = fixture_response(:open_saml_response, false)
+        document = XMLSecurity::SignedDocument.new(response)
+        inclusive_namespaces = document.send(:extract_inclusive_namespaces)
+
+        inclusive_namespaces.should == %w[xs]
+      end
+
+      it "support implicit namespace resolution for exclusive canonicalization" do
+        response = fixture_response(:no_signature_ns, false)
+        document = XMLSecurity::SignedDocument.new(response)
+        inclusive_namespaces = document.send(:extract_inclusive_namespaces)
+
+        inclusive_namespaces.should == %w[#default saml ds xs xsi]
+      end
+
+      it "return an empty list when inclusive namespace element is missing" do
+        response = fixture_response(:no_signature_ns, false)
+        response.slice! %r{<InclusiveNamespaces xmlns="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="#default saml ds xs xsi"/>}
+
+        document = XMLSecurity::SignedDocument.new(response)
+        inclusive_namespaces = document.send(:extract_inclusive_namespaces)
+
+        inclusive_namespaces.should be_empty
+      end
+    end
+
+    describe "StarfieldTMS" do
+      let(:response) { ::OneLogin::RubySaml::Response.new(fixture_response(:starfield_response)) }
+
+      before do
+        response.settings = ::OneLogin::RubySaml::Settings.new(
+          :idp_cert_fingerprint => "8D:BA:53:8E:A3:B6:F9:F1:69:6C:BB:D9:D8:BD:41:B3:AC:4F:9D:4D"
+        )
+      end
+
+      it "be able to validate a good response" do
+        Timecop.freeze Time.parse('2012-11-28 17:55:00 UTC') do
+          response.validate!.should be_truthy
+        end
+      end
+
+      it "fail before response is valid" do
+        Timecop.freeze Time.parse('2012-11-20 17:55:00 UTC') do
+          response.should_not be_is_valid
+        end
+      end
+
+      it "fail after response expires" do
+        Timecop.freeze Time.parse('2012-11-30 17:55:00 UTC') do
+          response.should_not be_is_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since SAML uses pre-exchanged certs, the trust chain is less useful anyways. Go back to xml_security.rb since it removes some integration woes.
